### PR TITLE
Improve player block spawn

### DIFF
--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -185,7 +185,7 @@ public class RerollHandler {
         }
 
         if (newPosition != null) {
-            entityPlayer.setPositionAndUpdate(newPosition.getX(), newPosition.getY() + 2.5f, newPosition.getZ());
+            entityPlayer.setPositionAndUpdate(newPosition.getX() + 0.5d, newPosition.getY() + 1.5d, newPosition.getZ() + 0.5d);
         } else {
             entityPlayer.sendMessage(new TextComponentTranslation("commands.reroll.max_tries"));
         }

--- a/src/main/java/com/smashingmods/reroll/mixin/WorldMixin.java
+++ b/src/main/java/com/smashingmods/reroll/mixin/WorldMixin.java
@@ -26,6 +26,6 @@ public class WorldMixin {
         BlockPos currentPosition = player.getPosition();
         World world = player.getEntityWorld();
         Optional<BlockPos> spawnBlock = PositionUtil.findClosest(currentPosition, Config.horizontalRange, Config.verticalRange, PositionUtil.blockStatePredicate(world));
-        spawnBlock.ifPresent(blockPos -> player.setPositionAndUpdate(blockPos.getX(), blockPos.getY() + 0.5f, blockPos.getZ()));
+        spawnBlock.ifPresent(blockPos -> player.setPositionAndUpdate(blockPos.getX() + 0.5d, blockPos.getY() + 1.5d, blockPos.getZ() + 0.5d));
     }
 }


### PR DESCRIPTION
Player now spawns in the center of the block, as well as above it instead of inside the block. Fixes #30 