### PR TITLE
Fix initial reroll location, add Elenai Dodge & Scaling Health mod support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     compile fg.deobf("curse.maven:timeisup-437596:3511732")
     compile fg.deobf("curse.maven:baubles-227083:2518667")
     compile fg.deobf("curse.maven:elenaidodge2-442962:3343308")
+    compile fg.deobf("curse.maven:silent-lib-242998:2851111")
+    compile fg.deobf("curse.maven:scaling-health-248027:2816920")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     compile fg.deobf("curse.maven:timeisup-437596:3511732")
     compile fg.deobf("curse.maven:baubles-227083:2518667")
+    compile fg.deobf("curse.maven:elenaidodge2-442962:3343308")
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 mod_id=reroll
-mod_version=1.5.5
+mod_version=1.5.6
 minecraft_version=1.12.2
 forge_version=14.23.5.2860
 org.gradle.jvmargs=-Xmx3G

--- a/src/main/java/com/smashingmods/reroll/Reroll.java
+++ b/src/main/java/com/smashingmods/reroll/Reroll.java
@@ -39,6 +39,7 @@ public class Reroll {
     public static boolean MODCOMPAT_TIMEISUP;
     public static boolean MODCOMPAT_BAUBLES;
     public static boolean MODCOMPAT_ELENAIDODGE;
+    public static boolean SCALING_HEALTH;
 
     @GameRegistry.ObjectHolder(DiceItem.name)
     public static final Item diceItem = Items.AIR;
@@ -64,6 +65,7 @@ public class Reroll {
         MODCOMPAT_TIMEISUP = Loader.isModLoaded("timeisup");
         MODCOMPAT_BAUBLES = Loader.isModLoaded("baubles");
         MODCOMPAT_ELENAIDODGE = Loader.isModLoaded("elenaidodge2");
+        SCALING_HEALTH = Loader.isModLoaded("scalinghealth");
 
         if (CONFIG.hasChanged()) {
             CONFIG.save();

--- a/src/main/java/com/smashingmods/reroll/Reroll.java
+++ b/src/main/java/com/smashingmods/reroll/Reroll.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 
-@Mod(modid = Reroll.MODID, version = "1.12.2-1.5.5", useMetadata = true)
+@Mod(modid = Reroll.MODID, version = "1.12.2-1.5.6", useMetadata = true)
 @Mod.EventBusSubscriber
 public class Reroll {
     public static final String MODID = "reroll";
@@ -38,6 +38,7 @@ public class Reroll {
     // Mod Compatibility
     public static boolean MODCOMPAT_TIMEISUP;
     public static boolean MODCOMPAT_BAUBLES;
+    public static boolean MODCOMPAT_ELENAIDODGE;
 
     @GameRegistry.ObjectHolder(DiceItem.name)
     public static final Item diceItem = Items.AIR;
@@ -62,6 +63,7 @@ public class Reroll {
     public void postInit(FMLPostInitializationEvent event) {
         MODCOMPAT_TIMEISUP = Loader.isModLoaded("timeisup");
         MODCOMPAT_BAUBLES = Loader.isModLoaded("baubles");
+        MODCOMPAT_ELENAIDODGE = Loader.isModLoaded("elenaidodge2");
 
         if (CONFIG.hasChanged()) {
             CONFIG.save();

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -34,9 +34,6 @@ public class PlayerLoginEvent {
             if (event.player instanceof EntityPlayerMP) {
                 EntityPlayerMP entityPlayer = (EntityPlayerMP) event.player;
 
-                RerollHandler handler = new RerollHandler();
-                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
-
                 setInitialCooldown(entityPlayer);
 
                 RerollCapabilityImplementation rerollCapability = entityPlayer.getCapability(RerollCapability.REROLL_CAPABILITY, null);
@@ -52,6 +49,10 @@ public class PlayerLoginEvent {
                         rerollCapability.setLock(true);
                     }
                 }
+
+                RerollHandler handler = new RerollHandler();
+                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
+                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
             }
         }
     }

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -5,10 +5,9 @@ import com.smashingmods.reroll.capability.RerollCapability;
 import com.smashingmods.reroll.capability.RerollCapabilityImplementation;
 import com.smashingmods.reroll.config.Config;
 import com.smashingmods.reroll.handler.InventoryHandler;
-import com.smashingmods.reroll.handler.RerollHandler;
 import com.smashingmods.reroll.item.DiceItem;
 import com.smashingmods.reroll.util.PositionUtil;
-import net.silentchaos512.scalinghealth.utils.SHPlayerDataHandler;
+import com.smashingmods.reroll.handler.ScalingHealthHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -59,11 +58,7 @@ public class PlayerLoginEvent {
                 }
 
                 if (Reroll.SCALING_HEALTH) {
-                    SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
-                    if (playerData != null) {
-                        entityPlayer.setHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
-                        playerData.setMaxHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
-                    }
+                    ScalingHealthHandler.setScalingHealth(entityPlayer);
                 }
             }
         }

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -5,16 +5,13 @@ import com.smashingmods.reroll.capability.RerollCapability;
 import com.smashingmods.reroll.capability.RerollCapabilityImplementation;
 import com.smashingmods.reroll.config.Config;
 import com.smashingmods.reroll.handler.InventoryHandler;
+import com.smashingmods.reroll.handler.RerollHandler;
 import com.smashingmods.reroll.item.DiceItem;
-import com.smashingmods.reroll.util.PositionUtil;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.CooldownTracker;
 import net.minecraft.util.NonNullList;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 
@@ -34,10 +31,11 @@ public class PlayerLoginEvent {
             // Set tag to prevent initial settings every login
             event.player.getTags().add("joined");
 
-            setPlayerToBlock(event.player);
-
             if (event.player instanceof EntityPlayerMP) {
                 EntityPlayerMP entityPlayer = (EntityPlayerMP) event.player;
+
+                RerollHandler handler = new RerollHandler();
+                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
 
                 setInitialCooldown(entityPlayer);
 
@@ -56,14 +54,6 @@ public class PlayerLoginEvent {
                 }
             }
         }
-    }
-
-    private static void setPlayerToBlock(EntityPlayer player) {
-        BlockPos currentPosition = player.getPosition();
-        World world = player.getEntityWorld();
-        Optional<BlockPos> spawnBlock = PositionUtil.findClosest(currentPosition, Config.horizontalRange, Config.verticalRange, PositionUtil.blockStatePredicate(world));
-        spawnBlock.ifPresent(blockPos -> player.setPositionAndUpdate(blockPos.getX() + 0.5d, blockPos.getY() + 1.5d, blockPos.getZ() + 0.5d));
-        spawnBlock.ifPresent(blockPos -> Reroll.LOGGER.info("Player {} was teleported to a suitable spawn block at {}, {}, {}", player.getName(), blockPos.getX() + 0.5d, blockPos.getY() + 1.5d, blockPos.getZ() + 0.5d));
     }
 
     private static void setInitialCooldown(EntityPlayerMP entityPlayer) {

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -8,6 +8,7 @@ import com.smashingmods.reroll.handler.InventoryHandler;
 import com.smashingmods.reroll.handler.RerollHandler;
 import com.smashingmods.reroll.item.DiceItem;
 import com.smashingmods.reroll.util.PositionUtil;
+import net.silentchaos512.scalinghealth.utils.SHPlayerDataHandler;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -54,6 +55,13 @@ public class PlayerLoginEvent {
                     }
                     if (Config.startLocked) {
                         rerollCapability.setLock(true);
+                    }
+                }
+
+                if (Reroll.SCALING_HEALTH) {
+                    SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
+                    if (playerData != null) {
+                        entityPlayer.setHealth(playerData.getMaxHealth());
                     }
                 }
             }

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -7,11 +7,16 @@ import com.smashingmods.reroll.config.Config;
 import com.smashingmods.reroll.handler.InventoryHandler;
 import com.smashingmods.reroll.handler.RerollHandler;
 import com.smashingmods.reroll.item.DiceItem;
+import com.smashingmods.reroll.util.PositionUtil;
+
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.CooldownTracker;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 
@@ -31,6 +36,8 @@ public class PlayerLoginEvent {
             // Set tag to prevent initial settings every login
             event.player.getTags().add("joined");
 
+            setPlayerToBlock(event.player);
+
             if (event.player instanceof EntityPlayerMP) {
                 EntityPlayerMP entityPlayer = (EntityPlayerMP) event.player;
 
@@ -49,12 +56,16 @@ public class PlayerLoginEvent {
                         rerollCapability.setLock(true);
                     }
                 }
-
-                RerollHandler handler = new RerollHandler();
-                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
-                handler.resetLocation(entityPlayer.getServer(), entityPlayer, true);
             }
         }
+    }
+
+    private static void setPlayerToBlock(EntityPlayer player) {
+        World world = player.getEntityWorld();
+        BlockPos currentPosition = player.getPosition();
+        currentPosition = currentPosition.add(currentPosition.getX() > 0 ? Config.minDistance : -Config.minDistance, 0, currentPosition.getZ() > 0 ? Config.minDistance : -Config.minDistance);
+        Optional<BlockPos> spawnBlock = PositionUtil.findClosest(currentPosition, Config.horizontalRange, Config.verticalRange, PositionUtil.blockStatePredicate(world));
+        spawnBlock.ifPresent(blockPos -> player.setPositionAndUpdate(blockPos.getX() + 0.5d, blockPos.getY() + 1.5d, blockPos.getZ() + 0.5d));
     }
 
     private static void setInitialCooldown(EntityPlayerMP entityPlayer) {

--- a/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
+++ b/src/main/java/com/smashingmods/reroll/events/PlayerLoginEvent.java
@@ -61,7 +61,8 @@ public class PlayerLoginEvent {
                 if (Reroll.SCALING_HEALTH) {
                     SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
                     if (playerData != null) {
-                        entityPlayer.setHealth(playerData.getMaxHealth());
+                        entityPlayer.setHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
+                        playerData.setMaxHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
                     }
                 }
             }

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -179,8 +179,6 @@ public class RerollHandler {
             world = server.getWorld(entityPlayer.getSpawnDimension());
         }
 
-        newPosition = generateValidBlockPos(world, next);
-
         if (!Config.useCurrentDim) {
             CommandSetDimension setDimension = new CommandSetDimension();
             try {
@@ -195,11 +193,10 @@ public class RerollHandler {
             entityPlayer.setSpawnDimension(entityPlayer.dimension);
         }
 
+        newPosition = generateValidBlockPos(world, next);
+
         if (newPosition != null) {
-            Reroll.LOGGER.debug("Old reroll position: " + PositionUtil.oldPos);
-            Reroll.LOGGER.debug("New reroll position: " + newPosition);
             entityPlayer.setPositionAndUpdate(newPosition.getX() + 0.5d, newPosition.getY() + 1.5d, newPosition.getZ() + 0.5d);
-            PositionUtil.oldPos = newPosition;
         } else {
             entityPlayer.sendMessage(new TextComponentTranslation("commands.reroll.max_tries"));
         }

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -26,7 +26,6 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.server.command.CommandSetDimension;
-import net.silentchaos512.scalinghealth.utils.SHPlayerDataHandler;
 import timeisup.TimeIsUp;
 import timeisup.capabilities.Timer;
 import timeisup.capabilities.TimerCapability;
@@ -167,11 +166,7 @@ public class RerollHandler {
         }
 
         if (Reroll.SCALING_HEALTH) {
-            SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
-            if (playerData != null) {
-                entityPlayer.setHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
-                playerData.setMaxHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
-            }
+            ScalingHealthHandler.setScalingHealth(entityPlayer);
         }
     }
 

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -26,6 +26,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.server.command.CommandSetDimension;
+import net.silentchaos512.scalinghealth.utils.SHPlayerDataHandler;
 import timeisup.TimeIsUp;
 import timeisup.capabilities.Timer;
 import timeisup.capabilities.TimerCapability;
@@ -162,6 +163,13 @@ public class RerollHandler {
             if (dodges != null) {
                 dodges.set(20);
                 com.elenai.elenaidodge2.network.PacketHandler.instance.sendTo(new CUpdateDodgeMessage(dodges.getDodges()), entityPlayer);
+            }
+        }
+
+        if (Reroll.SCALING_HEALTH) {
+            SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
+            if (playerData != null) {
+                entityPlayer.setHealth(playerData.getMaxHealth());
             }
         }
     }

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -2,7 +2,9 @@ package com.smashingmods.reroll.handler;
 
 import baubles.api.BaublesApi;
 import baubles.api.inv.BaublesInventoryWrapper;
-import com.elenai.elenaidodge2.api.FeathersHelper;
+import com.elenai.elenaidodge2.capability.dodges.DodgesProvider;
+import com.elenai.elenaidodge2.capability.dodges.IDodges;
+import com.elenai.elenaidodge2.network.message.CUpdateDodgeMessage;
 import com.smashingmods.reroll.Reroll;
 import com.smashingmods.reroll.capability.WorldSavedData;
 import com.smashingmods.reroll.config.Config;
@@ -156,7 +158,11 @@ public class RerollHandler {
         }
 
         if (Reroll.MODCOMPAT_ELENAIDODGE) {
-            FeathersHelper.increaseFeathers(entityPlayer, 20);
+            IDodges dodges = entityPlayer.getCapability(DodgesProvider.DODGES_CAP, null);
+            if (dodges != null) {
+                dodges.set(20);
+                com.elenai.elenaidodge2.network.PacketHandler.instance.sendTo(new CUpdateDodgeMessage(dodges.getDodges()), entityPlayer);
+            }
         }
     }
 

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -160,7 +160,7 @@ public class RerollHandler {
         }
     }
 
-    private void resetLocation(MinecraftServer server, EntityPlayerMP entityPlayer, boolean next) {
+    public void resetLocation(MinecraftServer server, EntityPlayerMP entityPlayer, boolean next) {
 
         WorldServer world;
         BlockPos newPosition;

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -196,7 +196,10 @@ public class RerollHandler {
         }
 
         if (newPosition != null) {
+            Reroll.LOGGER.debug("Old reroll position: " + PositionUtil.oldPos);
+            Reroll.LOGGER.debug("New reroll position: " + newPosition);
             entityPlayer.setPositionAndUpdate(newPosition.getX() + 0.5d, newPosition.getY() + 1.5d, newPosition.getZ() + 0.5d);
+            PositionUtil.oldPos = newPosition;
         } else {
             entityPlayer.sendMessage(new TextComponentTranslation("commands.reroll.max_tries"));
         }

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -169,7 +169,8 @@ public class RerollHandler {
         if (Reroll.SCALING_HEALTH) {
             SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
             if (playerData != null) {
-                entityPlayer.setHealth(playerData.getMaxHealth());
+                entityPlayer.setHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
+                playerData.setMaxHealth(net.silentchaos512.scalinghealth.config.Config.Player.Health.startingHealth);
             }
         }
     }

--- a/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/RerollHandler.java
@@ -2,6 +2,7 @@ package com.smashingmods.reroll.handler;
 
 import baubles.api.BaublesApi;
 import baubles.api.inv.BaublesInventoryWrapper;
+import com.elenai.elenaidodge2.api.FeathersHelper;
 import com.smashingmods.reroll.Reroll;
 import com.smashingmods.reroll.capability.WorldSavedData;
 import com.smashingmods.reroll.config.Config;
@@ -152,6 +153,10 @@ public class RerollHandler {
         if (Reroll.MODCOMPAT_BAUBLES) {
             BaublesInventoryWrapper wrapper = new BaublesInventoryWrapper(BaublesApi.getBaublesHandler(entityPlayer));
             wrapper.func_174888_l();
+        }
+
+        if (Reroll.MODCOMPAT_ELENAIDODGE) {
+            FeathersHelper.increaseFeathers(entityPlayer, 20);
         }
     }
 

--- a/src/main/java/com/smashingmods/reroll/handler/ScalingHealthHandler.java
+++ b/src/main/java/com/smashingmods/reroll/handler/ScalingHealthHandler.java
@@ -1,0 +1,16 @@
+package com.smashingmods.reroll.handler;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.silentchaos512.scalinghealth.config.Config;
+import net.silentchaos512.scalinghealth.utils.SHPlayerDataHandler;
+
+public class ScalingHealthHandler {
+
+    public static void setScalingHealth(EntityPlayerMP entityPlayer) {
+        SHPlayerDataHandler.PlayerData playerData = SHPlayerDataHandler.get(entityPlayer);
+        if (playerData != null) {
+            entityPlayer.setHealth(Config.Player.Health.startingHealth);
+            playerData.setMaxHealth(Config.Player.Health.startingHealth);
+        }
+    }
+}

--- a/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
+++ b/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
@@ -16,6 +16,8 @@ import java.util.function.Predicate;
 
 public class PositionUtil {
 
+    private static BlockPos oldPos;
+
     public static List<Block> getSpawnBlocks() {
         List<Block> blocks = new ArrayList<>();
 
@@ -29,6 +31,7 @@ public class PositionUtil {
 
     public static Predicate<BlockPos> blockStatePredicate(World world) {
         return position ->
+            position != oldPos &&
             getSpawnBlocks().contains(world.getBlockState(position).getBlock()) &&
             world.canBlockSeeSky(position) &&
             world.isAirBlock(position.up(1)) &&
@@ -40,6 +43,7 @@ public class PositionUtil {
     public static Optional<BlockPos> findClosest(BlockPos pos, int horizontalRange, int verticalRange, Predicate<BlockPos> condition) {
         for (BlockPos blockPos : iterateOutwards(pos, horizontalRange, verticalRange, horizontalRange)) {
             if (condition.test(blockPos)) {
+                oldPos = blockPos;
                 return Optional.of(blockPos);
             }
         }

--- a/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
+++ b/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
@@ -16,8 +16,6 @@ import java.util.function.Predicate;
 
 public class PositionUtil {
 
-    public static BlockPos oldPos;
-
     public static List<Block> getSpawnBlocks() {
         List<Block> blocks = new ArrayList<>();
 
@@ -31,8 +29,6 @@ public class PositionUtil {
 
     public static Predicate<BlockPos> blockStatePredicate(World world) {
         return position ->
-            (oldPos == null || position.getX() < oldPos.getX() - (Config.horizontalRange / 2) || position.getX() > oldPos.getX() + (Config.horizontalRange / 2)) &&
-            (oldPos == null || position.getZ() < oldPos.getZ() - (Config.horizontalRange / 2) || position.getZ() > oldPos.getZ() + (Config.horizontalRange / 2)) &&
             getSpawnBlocks().contains(world.getBlockState(position).getBlock()) &&
             world.canBlockSeeSky(position) &&
             world.isAirBlock(position.up(1)) &&

--- a/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
+++ b/src/main/java/com/smashingmods/reroll/util/PositionUtil.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
 
 public class PositionUtil {
 
-    private static BlockPos oldPos;
+    public static BlockPos oldPos;
 
     public static List<Block> getSpawnBlocks() {
         List<Block> blocks = new ArrayList<>();
@@ -31,7 +31,8 @@ public class PositionUtil {
 
     public static Predicate<BlockPos> blockStatePredicate(World world) {
         return position ->
-            position != oldPos &&
+            (oldPos == null || position.getX() < oldPos.getX() - (Config.horizontalRange / 2) || position.getX() > oldPos.getX() + (Config.horizontalRange / 2)) &&
+            (oldPos == null || position.getZ() < oldPos.getZ() - (Config.horizontalRange / 2) || position.getZ() > oldPos.getZ() + (Config.horizontalRange / 2)) &&
             getSpawnBlocks().contains(world.getBlockState(position).getBlock()) &&
             world.canBlockSeeSky(position) &&
             world.isAirBlock(position.up(1)) &&
@@ -43,7 +44,6 @@ public class PositionUtil {
     public static Optional<BlockPos> findClosest(BlockPos pos, int horizontalRange, int verticalRange, Predicate<BlockPos> condition) {
         for (BlockPos blockPos : iterateOutwards(pos, horizontalRange, verticalRange, horizontalRange)) {
             if (condition.test(blockPos)) {
-                oldPos = blockPos;
                 return Optional.of(blockPos);
             }
         }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
   "modid": "reroll",
   "name": "Reroll",
   "description": "Reroll is a mod designed to completely reroll or reset a player. It will remove their inventory, achievements, etc. and teleport them far away to simulate a completely new world. This is great for hardcore style modpacks that don't want to create new worlds for every reset. It works in single player and on servers.",
-  "version": "1.12.2-1.5.5",
+  "version": "1.12.2-1.5.6",
   "mcversion": "1.12.2",
   "authorList": ["DarkArcana"],
   "logoFile": "reroll-logo.png"


### PR DESCRIPTION
This was a rather wild ride and involved quite a bit of trial and error, but through persistent testing by @CalaMariGold we reached a satisfactory outcome:
- Rerolling respects minimum distance on initial spawn (fixes #28 in the process)
- Elenai Dodge support: Amount of dodges resets upon rerolling (closes #29)
- Scaling Health support: Leveled health resets upon rerolling